### PR TITLE
Add a shebang and set the mode to 744

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ By relying on the PHP tokenizer, nothing but the array syntax itself will be alt
 Usage
 ================================
 
-    Usage: php convert.php [-w] <file>
+    Usage: ./convert.php [-w] <file>
     
 Run the script with the path of the PHP file you wish to convert as argument. This will print the converted source code to STDOUT. 
     
@@ -19,7 +19,7 @@ In case of any error, an error message is written to STDERR and the script exits
 
 Use `find` to convert a whole directory recursively:
 
-    find <directory> -name "*.php" -exec php "convert.php" -w "{}" \;
+    find <directory> -name "*.php" -exec ./convert.php -w "{}" \;
     
 In case you don't trust the script yet, you can even perform a syntax check after conversion:
 

--- a/convert.php
+++ b/convert.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 /**


### PR DESCRIPTION
This way the script can be executed from the command line as follows:

```
$ ./convert.php -w File.php
```

I've also updated the readme accordingly.
