### PR TITLE
Added revert functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHP 5.4 Short Array Syntax Converter
 ================================
 
-Command-line script to convert PHP's `array()` syntax to PHP 5.4's short array syntax `[]` using PHP's built-in tokenizer.
+Command-line script to convert and revert PHP's `array()` syntax to PHP 5.4's short array syntax`[]` using PHP's built-in tokenizer.
 
 By relying on the PHP tokenizer, nothing but the array syntax itself will be altered. The script was successfully tested against code bases with more than 5.000 PHP files.
 
@@ -10,6 +10,7 @@ Usage
 ================================
 
     Usage: php convert.php [-w] <file>
+
     
 Run the script with the path of the PHP file you wish to convert as argument. This will print the converted source code to STDOUT. 
     
@@ -24,6 +25,15 @@ Use `find` to convert a whole directory recursively:
 In case you don't trust the script yet, you can even perform a syntax check after conversion:
 
     find <directory> -name "*.php" -exec php -l "{}" \; | grep "error:"
+
+Revert
+================================
+
+    Usage: php revert.php [-w] <file>
+
+Reverting has not yet been thoroughly tested, so use with extreme percaution!
+
+Since there is no specific token for the short array syntax, it relies on checking the previous token for a variable, object property or function return ")".
 
 
 Thanks to

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Revert
 
     Usage: php revert.php [-w] <file>
 
-Reverting has not yet been thoroughly tested, so use with extreme percaution!
+**Reverting has not yet been thoroughly tested, so use with extreme percaution!**
 
-Since there is no specific token for the short array syntax, it relies on checking the previous token for a variable, object property or function return ")".
+Since there is no specific token for the short array syntax, it assumes every "[" is an aray and relies on checking the previous token for a variable, object property, function return ")", nested array "]" and variable reference "}".
 
 
 Thanks to

--- a/revert.php
+++ b/revert.php
@@ -76,9 +76,6 @@ for ($i = 0; $i < count($tokens); ++$i) {
 		$subOffset = $offset;
 		for ($j = $i - 1; $j > 0; $j--) {
 			$subOffset -= strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
-			//echo (is_string($tokens[$j])) ? $tokens[$j] : token_name($tokens[$j][0]) . ':' . $tokens[$j][1];
-			//echo "\n";
-
 
 			if (is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
 				$subOffset += strlen($tokens[$j][1]);
@@ -101,7 +98,6 @@ for ($i = 0; $i < count($tokens); ++$i) {
 		}
 
 		if ($isArraySyntax) {
-
 			// Replace "[" with "array("
 			$replacements[] = array(
 				'start' => $offset - strlen($tokens[$i]),

--- a/revert.php
+++ b/revert.php
@@ -2,59 +2,60 @@
 /**
  * PHP 5.4 Short Array Syntax Reverter
  *
- * Command-line script to convert PHP 5.4's short array syntax "[]" syntax 
+ * Command-line script to convert PHP 5.4's short array syntax "[]" syntax
  * to PHP 5.4's standard "array()" syntax using PHP's built-in tokenizer.
- * 
+ *
  * This script is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License (LGPL) as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This script is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
- * 
+ *
  * @link      https://github.com/thomasbachem/php-short-array-syntax-converter
  *
  * @link      http://php.net/manual/en/language.types.array.php
- * 
+ *
  * @license   http://www.gnu.org/licenses/lgpl.html
  * @author    Thomas Bachem <mail@thomasbachem.com>
  */
+
 // - - - - - HANDLE COMMAND LINE ARGUMENTS - - - - -
 
 $filePath = null;
 $saveFile = false;
 
-if($argc > 3) {
-        file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
-        exit(1);
+if ($argc > 3) {
+    file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
+    exit(1);
 }
-for($i = 1; $i < $argc; ++$i) {
-        if($argv[$i] && $argv[$i][0] == '-') {
-                $saveFile = ($argv[$i] == '-w');
-        } else {
-                $filePath = $argv[$i];
-        }
+for ($i = 1; $i < $argc; ++$i) {
+    if ($argv[$i] && $argv[$i][0] == '-') {
+        $saveFile = ($argv[$i] == '-w');
+    } else {
+        $filePath = $argv[$i];
+    }
 }
 
-if(!$filePath) {
-        file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
-        exit(1);
-} elseif(!file_exists($filePath)) {
-        file_put_contents('php://stderr', 'File "' . $filePath . '" not found.' . "\n");
-        exit(1);
+if (!$filePath) {
+    file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
+    exit(1);
+} elseif (!file_exists($filePath)) {
+    file_put_contents('php://stderr', 'File "' . $filePath . '" not found.' . "\n");
+    exit(1);
 }
 
 
 // - - - - - READ ORIGINAL CODE - - - - -
 
-$code   = file_get_contents($filePath);
+$code = file_get_contents($filePath);
 $tokens = token_get_all($code);
 
 
@@ -62,95 +63,94 @@ $tokens = token_get_all($code);
 
 $replacements = array();
 $offset = 0;
-for($i = 0; $i < count($tokens); ++$i) {
-        // Keep track of the current byte offset in the source code
-        $offset += strlen(is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i]);
-        
-        // "[" literal could either be an array index pointer 
-        // or an array definition
-        if(is_string($tokens[$i]) && $tokens[$i] === "[") {
-                
-                // Assume we're looking at an array definition by default
-                $isArraySyntax = true;
-                $subOffset = $offset;
-                for($j = $i - 1; $j > 0; $j--) {
-                    $subOffset -= strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
-                    echo (is_string($tokens[$j])) ? $tokens[$j] : token_name($tokens[$j][0]) . ':' . $tokens[$j][1];
-                    echo "\n";
-                    
-                    
-                    if (is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE){
-                            $subOffset += strlen($tokens[$j][1]);
-                            continue;
-                    }
-                    // Look for a previous variable or function return
-                    // to make sure we're not looking at an array pointer
-                    elseif (
-                                (is_array($tokens[$j]) && (
-                                        $tokens[$j][0] === T_VARIABLE
-                                        || $tokens[$j][0] === T_STRING
-                                        )
-                                )
-                                || in_array($tokens[$j], array(')', ']', '}'), true)
-                            ){
-                        $isArraySyntax = false;
-                        break;
-                    }
-                    else {
-                        
-                        break;
-                    }
-                }
-                
-                if($isArraySyntax) {
-                        
-                        // Replace "[" with "array("
-                        $replacements[] = array(
-                                'start'  => $offset - strlen($tokens[$i]),
-                                'end'    => $offset,
-                                'string' => 'array(',
-                        );
-                        
-                        // Look for matching closing bracket ("]")
-                        $subOffset = $offset;
-                        $openBracketsCount = 1;
-                        for($j = $i + 1; $j < count($tokens); ++$j) {
-                                $subOffset += strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
-                                
-                                if(is_string($tokens[$j]) && $tokens[$j] == '[') {
-                                        ++$openBracketsCount;
-                                } elseif(is_string($tokens[$j]) && $tokens[$j] == ']') {
-                                        --$openBracketsCount;
-                                        if($openBracketsCount == 0) {
-                                                // Replace "]" with ")"
-                                                $replacements[] = array(
-                                                        'start'  => $subOffset - 1,
-                                                        'end'    => $subOffset,
-                                                        'string' => ')',
-                                                );
-                                                break;
-                                        }
-                                }
-                        }
-                }
+for ($i = 0; $i < count($tokens); ++$i) {
+    // Keep track of the current byte offset in the source code
+    $offset += strlen(is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i]);
+
+    // "[" literal could either be an array index pointer
+    // or an array definition
+    if (is_string($tokens[$i]) && $tokens[$i] === "[") {
+
+        // Assume we're looking at an array definition by default
+        $isArraySyntax = true;
+        $subOffset = $offset;
+        for ($j = $i - 1; $j > 0; $j--) {
+            $subOffset -= strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
+            //echo (is_string($tokens[$j])) ? $tokens[$j] : token_name($tokens[$j][0]) . ':' . $tokens[$j][1];
+            //echo "\n";
+
+
+            if (is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                $subOffset += strlen($tokens[$j][1]);
+                continue;
+            }
+            // Look for a previous variable or function return
+            // to make sure we're not looking at an array pointer
+            elseif (
+                (is_array($tokens[$j]) && (
+                $tokens[$j][0] === T_VARIABLE || $tokens[$j][0] === T_STRING
+                )
+                ) || in_array($tokens[$j], array(')', ']', '}'), true)
+            ) {
+                $isArraySyntax = false;
+                break;
+            } else {
+
+                break;
+            }
         }
+
+        if ($isArraySyntax) {
+
+            // Replace "[" with "array("
+            $replacements[] = array(
+                'start' => $offset - strlen($tokens[$i]),
+                'end' => $offset,
+                'string' => 'array(',
+            );
+
+            // Look for matching closing bracket ("]")
+            $subOffset = $offset;
+            $openBracketsCount = 1;
+            for ($j = $i + 1; $j < count($tokens); ++$j) {
+                $subOffset += strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
+
+                if (is_string($tokens[$j]) && $tokens[$j] == '[') {
+                    ++$openBracketsCount;
+                } elseif (is_string($tokens[$j]) && $tokens[$j] == ']') {
+                    --$openBracketsCount;
+                    if ($openBracketsCount == 0) {
+                        // Replace "]" with ")"
+                        $replacements[] = array(
+                            'start' => $subOffset - 1,
+                            'end' => $subOffset,
+                            'string' => ')',
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }
 
 
 // - - - - - UPDATE CODE - - - - -
-
 // Apply the replacements to the source code
 $offsetChange = 0;
-foreach($replacements as $replacement) {
-        $code = substr_replace($code, $replacement['string'], $replacement['start'] + $offsetChange, $replacement['end'] - $replacement['start']);
-        $offsetChange += strlen($replacement['string']) - ($replacement['end'] - $replacement['start']);
+foreach ($replacements as $replacement) {
+    $code = substr_replace($code, $replacement['string'], $replacement['start'] + $offsetChange, $replacement['end'] - $replacement['start']);
+    $offsetChange += strlen($replacement['string']) - ($replacement['end'] - $replacement['start']);
 }
 
 
 // - - - - - OUTPUT/WRITE NEW CODE - - - - -
 
-if($saveFile) {
+if ($saveFile) {
+    if (count($replacements) > 0) {
         file_put_contents($filePath, $code);
+        echo count($replacements) . ' replacements';
+    }
 } else {
-        print $code;
+    print $code;
 }

--- a/revert.php
+++ b/revert.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * PHP 5.4 Short Array Syntax Reverter
+ *
+ * Command-line script to convert PHP 5.4's short array syntax "[]" syntax 
+ * to PHP 5.4's standard "array()" syntax using PHP's built-in tokenizer.
+ * 
+ * This script is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License (LGPL) as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ * 
+ * @link      https://github.com/thomasbachem/php-short-array-syntax-converter
+ *
+ * @link      http://php.net/manual/en/language.types.array.php
+ * 
+ * @license   http://www.gnu.org/licenses/lgpl.html
+ * @author    Thomas Bachem <mail@thomasbachem.com>
+ */
+// - - - - - HANDLE COMMAND LINE ARGUMENTS - - - - -
+
+$filePath = null;
+$saveFile = false;
+
+if($argc > 3) {
+        file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
+        exit(1);
+}
+for($i = 1; $i < $argc; ++$i) {
+        if($argv[$i] && $argv[$i][0] == '-') {
+                $saveFile = ($argv[$i] == '-w');
+        } else {
+                $filePath = $argv[$i];
+        }
+}
+
+if(!$filePath) {
+        file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
+        exit(1);
+} elseif(!file_exists($filePath)) {
+        file_put_contents('php://stderr', 'File "' . $filePath . '" not found.' . "\n");
+        exit(1);
+}
+
+
+// - - - - - READ ORIGINAL CODE - - - - -
+
+$code   = file_get_contents($filePath);
+$tokens = token_get_all($code);
+
+
+// - - - - - PARSE CODE - - - - -
+
+$replacements = array();
+$offset = 0;
+for($i = 0; $i < count($tokens); ++$i) {
+        // Keep track of the current byte offset in the source code
+        $offset += strlen(is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i]);
+        
+        // "[" literal could either be an array index pointer 
+        // or an array definition
+        if(is_string($tokens[$i]) && $tokens[$i] === "[") {
+                
+                // Assume we're looking at an array definition by default
+                $isArraySyntax = true;
+                $subOffset = $offset;
+                for($j = $i - 1; $j > 0; $j--) {
+                    $subOffset -= strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
+                    echo (is_string($tokens[$j])) ? $tokens[$j] : token_name($tokens[$j][0]) . ':' . $tokens[$j][1];
+                    echo "\n";
+                    
+                    
+                    if (is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE){
+                            $subOffset += strlen($tokens[$j][1]);
+                            continue;
+                    }
+                    // Look for a previous variable or function return
+                    // to make sure we're not looking at an array pointer
+                    elseif (
+                                (is_array($tokens[$j]) && (
+                                        $tokens[$j][0] === T_VARIABLE
+                                        || $tokens[$j][0] === T_STRING
+                                        )
+                                )
+                                || in_array($tokens[$j], array(')', ']'), true)
+                            ){
+                        $isArraySyntax = false;
+                        break;
+                    }
+                    else {
+                        
+                        break;
+                    }
+                }
+                
+                if($isArraySyntax) {
+                        
+                        // Replace "[" with "array("
+                        $replacements[] = array(
+                                'start'  => $offset - strlen($tokens[$i]),
+                                'end'    => $offset,
+                                'string' => 'array(',
+                        );
+                        
+                        // Look for matching closing bracket ("]")
+                        $subOffset = $offset;
+                        $openBracketsCount = 1;
+                        for($j = $i + 1; $j < count($tokens); ++$j) {
+                                $subOffset += strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
+                                
+                                if(is_string($tokens[$j]) && $tokens[$j] == '[') {
+                                        ++$openBracketsCount;
+                                } elseif(is_string($tokens[$j]) && $tokens[$j] == ']') {
+                                        --$openBracketsCount;
+                                        if($openBracketsCount == 0) {
+                                                // Replace "]" with ")"
+                                                $replacements[] = array(
+                                                        'start'  => $subOffset - 1,
+                                                        'end'    => $subOffset,
+                                                        'string' => ')',
+                                                );
+                                                break;
+                                        }
+                                }
+                        }
+                }
+        }
+}
+
+
+// - - - - - UPDATE CODE - - - - -
+
+// Apply the replacements to the source code
+$offsetChange = 0;
+foreach($replacements as $replacement) {
+        $code = substr_replace($code, $replacement['string'], $replacement['start'] + $offsetChange, $replacement['end'] - $replacement['start']);
+        $offsetChange += strlen($replacement['string']) - ($replacement['end'] - $replacement['start']);
+}
+
+
+// - - - - - OUTPUT/WRITE NEW CODE - - - - -
+
+if($saveFile) {
+        file_put_contents($filePath, $code);
+} else {
+        print $code;
+}

--- a/revert.php
+++ b/revert.php
@@ -91,7 +91,7 @@ for($i = 0; $i < count($tokens); ++$i) {
                                         || $tokens[$j][0] === T_STRING
                                         )
                                 )
-                                || in_array($tokens[$j], array(')', ']'), true)
+                                || in_array($tokens[$j], array(')', ']', '}'), true)
                             ){
                         $isArraySyntax = false;
                         break;

--- a/revert.php
+++ b/revert.php
@@ -19,12 +19,12 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
  *
- * @link      https://github.com/thomasbachem/php-short-array-syntax-converter
+ * @link	  https://github.com/thomasbachem/php-short-array-syntax-converter
  *
- * @link      http://php.net/manual/en/language.types.array.php
+ * @link	  http://php.net/manual/en/language.types.array.php
  *
- * @license   http://www.gnu.org/licenses/lgpl.html
- * @author    Thomas Bachem <mail@thomasbachem.com>
+ * @license	  http://www.gnu.org/licenses/lgpl.html
+ * @author	  Thomas Bachem <mail@thomasbachem.com>
  */
 
 // - - - - - HANDLE COMMAND LINE ARGUMENTS - - - - -
@@ -33,23 +33,23 @@ $filePath = null;
 $saveFile = false;
 
 if ($argc > 3) {
-    file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
-    exit(1);
+	file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
+	exit(1);
 }
 for ($i = 1; $i < $argc; ++$i) {
-    if ($argv[$i] && $argv[$i][0] == '-') {
-        $saveFile = ($argv[$i] == '-w');
-    } else {
-        $filePath = $argv[$i];
-    }
+	if ($argv[$i] && $argv[$i][0] == '-') {
+		$saveFile = ($argv[$i] == '-w');
+	} else {
+		$filePath = $argv[$i];
+	}
 }
 
 if (!$filePath) {
-    file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
-    exit(1);
+	file_put_contents('php://stderr', 'Usage: php revert.php [-w] <file>' . "\n");
+	exit(1);
 } elseif (!file_exists($filePath)) {
-    file_put_contents('php://stderr', 'File "' . $filePath . '" not found.' . "\n");
-    exit(1);
+	file_put_contents('php://stderr', 'File "' . $filePath . '" not found.' . "\n");
+	exit(1);
 }
 
 
@@ -64,74 +64,74 @@ $tokens = token_get_all($code);
 $replacements = array();
 $offset = 0;
 for ($i = 0; $i < count($tokens); ++$i) {
-    // Keep track of the current byte offset in the source code
-    $offset += strlen(is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i]);
+	// Keep track of the current byte offset in the source code
+	$offset += strlen(is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i]);
 
-    // "[" literal could either be an array index pointer
-    // or an array definition
-    if (is_string($tokens[$i]) && $tokens[$i] === "[") {
+	// "[" literal could either be an array index pointer
+	// or an array definition
+	if (is_string($tokens[$i]) && $tokens[$i] === "[") {
 
-        // Assume we're looking at an array definition by default
-        $isArraySyntax = true;
-        $subOffset = $offset;
-        for ($j = $i - 1; $j > 0; $j--) {
-            $subOffset -= strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
-            //echo (is_string($tokens[$j])) ? $tokens[$j] : token_name($tokens[$j][0]) . ':' . $tokens[$j][1];
-            //echo "\n";
+		// Assume we're looking at an array definition by default
+		$isArraySyntax = true;
+		$subOffset = $offset;
+		for ($j = $i - 1; $j > 0; $j--) {
+			$subOffset -= strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
+			//echo (is_string($tokens[$j])) ? $tokens[$j] : token_name($tokens[$j][0]) . ':' . $tokens[$j][1];
+			//echo "\n";
 
 
-            if (is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
-                $subOffset += strlen($tokens[$j][1]);
-                continue;
-            }
-            // Look for a previous variable or function return
-            // to make sure we're not looking at an array pointer
-            elseif (
-                (is_array($tokens[$j]) && (
-                $tokens[$j][0] === T_VARIABLE || $tokens[$j][0] === T_STRING
-                )
-                ) || in_array($tokens[$j], array(')', ']', '}'), true)
-            ) {
-                $isArraySyntax = false;
-                break;
-            } else {
+			if (is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+				$subOffset += strlen($tokens[$j][1]);
+				continue;
+			}
+			// Look for a previous variable or function return
+			// to make sure we're not looking at an array pointer
+			elseif (
+				(is_array($tokens[$j]) && (
+				$tokens[$j][0] === T_VARIABLE || $tokens[$j][0] === T_STRING
+				)
+				) || in_array($tokens[$j], array(')', ']', '}'), true)
+			) {
+				$isArraySyntax = false;
+				break;
+			} else {
 
-                break;
-            }
-        }
+				break;
+			}
+		}
 
-        if ($isArraySyntax) {
+		if ($isArraySyntax) {
 
-            // Replace "[" with "array("
-            $replacements[] = array(
-                'start' => $offset - strlen($tokens[$i]),
-                'end' => $offset,
-                'string' => 'array(',
-            );
+			// Replace "[" with "array("
+			$replacements[] = array(
+				'start' => $offset - strlen($tokens[$i]),
+				'end' => $offset,
+				'string' => 'array(',
+			);
 
-            // Look for matching closing bracket ("]")
-            $subOffset = $offset;
-            $openBracketsCount = 1;
-            for ($j = $i + 1; $j < count($tokens); ++$j) {
-                $subOffset += strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
+			// Look for matching closing bracket ("]")
+			$subOffset = $offset;
+			$openBracketsCount = 1;
+			for ($j = $i + 1; $j < count($tokens); ++$j) {
+				$subOffset += strlen(is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j]);
 
-                if (is_string($tokens[$j]) && $tokens[$j] == '[') {
-                    ++$openBracketsCount;
-                } elseif (is_string($tokens[$j]) && $tokens[$j] == ']') {
-                    --$openBracketsCount;
-                    if ($openBracketsCount == 0) {
-                        // Replace "]" with ")"
-                        $replacements[] = array(
-                            'start' => $subOffset - 1,
-                            'end' => $subOffset,
-                            'string' => ')',
-                        );
-                        break;
-                    }
-                }
-            }
-        }
-    }
+				if (is_string($tokens[$j]) && $tokens[$j] == '[') {
+					++$openBracketsCount;
+				} elseif (is_string($tokens[$j]) && $tokens[$j] == ']') {
+					--$openBracketsCount;
+					if ($openBracketsCount == 0) {
+						// Replace "]" with ")"
+						$replacements[] = array(
+							'start' => $subOffset - 1,
+							'end' => $subOffset,
+							'string' => ')',
+						);
+						break;
+					}
+				}
+			}
+		}
+	}
 }
 
 
@@ -139,18 +139,18 @@ for ($i = 0; $i < count($tokens); ++$i) {
 // Apply the replacements to the source code
 $offsetChange = 0;
 foreach ($replacements as $replacement) {
-    $code = substr_replace($code, $replacement['string'], $replacement['start'] + $offsetChange, $replacement['end'] - $replacement['start']);
-    $offsetChange += strlen($replacement['string']) - ($replacement['end'] - $replacement['start']);
+	$code = substr_replace($code, $replacement['string'], $replacement['start'] + $offsetChange, $replacement['end'] - $replacement['start']);
+	$offsetChange += strlen($replacement['string']) - ($replacement['end'] - $replacement['start']);
 }
 
 
 // - - - - - OUTPUT/WRITE NEW CODE - - - - -
 
 if ($saveFile) {
-    if (count($replacements) > 0) {
-        file_put_contents($filePath, $code);
-        echo count($replacements) . ' replacements';
-    }
+	if (count($replacements) > 0) {
+		file_put_contents($filePath, $code);
+		echo count($replacements) . ' replacements';
+	}
 } else {
-    print $code;
+	print $code;
 }


### PR DESCRIPTION
The new revert.php script is based completely on convert.php and behaves pretty much the same from the CLI point of view.

Since finding an "[" array token is not possible, I have taken the approach to consider every "[" token as an array and check for what is *not* an array by checking **previous** tokens for variables, object properties, functions (which might return arrays) and variable references ($this->{$varname}['index']).

Tested on a badly conventioned app with 6.500 files with approx. 1.650 replacements. No false positives were found. Still checking for false negatives (missed instances).

This **should not be considered** a thourough test though, additional test must be carried out.
